### PR TITLE
Fixes problems parsing license ids and exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require('spdx-license-ids').forEach(function(id) {
   require('spdx-exceptions').forEach(function(e) {
     assert.deepEqual(
       parse(id + ' WITH ' + e),
-      { license: id, exception: e.trim() });
+      { license: id, exception: e });
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ var secondAST = {
 assert.deepEqual(
   parse('(MIT AND (LGPL-2.1+ AND BSD-3-Clause))'),
   secondAST)
+
+// We handle all the bare SPDX license and exception ids as well.
+require('spdx-license-ids').forEach(function(id) {
+  assert.deepEqual(
+    parse(id),
+    { license: id });
+  require('spdx-exceptions').forEach(function(e) {
+    assert.deepEqual(
+      parse(id + ' WITH ' + e),
+      { license: id, exception: e });
+  });
+});
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require('spdx-license-ids').forEach(function(id) {
   require('spdx-exceptions').forEach(function(e) {
     assert.deepEqual(
       parse(id + ' WITH ' + e),
-      { license: id, exception: e });
+      { license: id, exception: e.trim() });
   });
 });
 ```

--- a/generate-parser.js
+++ b/generate-parser.js
@@ -17,9 +17,6 @@ var handleLicensesAndExceptions = function() {
   var ids = require('spdx-license-ids');
   var exceptions = require('spdx-exceptions');
 
-  // Work around the fact that SPDX exception list has trailing whitespace.
-  exceptions = exceptions.map(function(s) { return s.trim(); });
-
   // Sort tokens longest-first (both license ids and exception strings)
   var tokens = ids.concat(exceptions);
   tokens.sort(function(a, b) { return b.length - a.length; });

--- a/generate-parser.js
+++ b/generate-parser.js
@@ -9,9 +9,25 @@ var words = [ 'AND', 'OR', 'WITH' ]
 var quote = function(argument) {
   return '\'' + argument + '\'' }
 
-var ret = function(token) {
-  return function(character) {
-    return [ character, 'return ' +  quote(token) ] } }
+var regexEscape = function(s) {
+  return s.replace(/[\^\\$*+?.()|{}\[\]\/]/g, '\\$&');
+};
+
+var handleLicensesAndExceptions = function() {
+  var ids = require('spdx-license-ids');
+  var exceptions = require('spdx-exceptions');
+
+  // Work around the fact that SPDX exception list has trailing whitespace.
+  exceptions = exceptions.map(function(s) { return s.trim(); });
+
+  // Sort tokens longest-first (both license ids and exception strings)
+  var tokens = ids.concat(exceptions);
+  tokens.sort(function(a, b) { return b.length - a.length; });
+  return tokens.map(function(t) {
+    var type = (ids.indexOf(t) >= 0) ? 'LICENSE' : 'EXCEPTION';
+    return [ regexEscape(t), 'return ' + quote(type) ];
+  });
+}
 
 var grammar = {
   lex: {
@@ -29,8 +45,7 @@ var grammar = {
         'return ' + quote('LICENSEREF') ] ]
       .concat(words.map(function(word) {
         return [ word, 'return ' + quote(word) ] }))
-      .concat(require('spdx-license-ids').map(ret('LICENSE')))
-      .concat(require('spdx-exceptions').map(ret('EXCEPTION'))) },
+      .concat(handleLicensesAndExceptions()) },
   operators: [
     [ 'left', 'OR' ],
     [ 'left', 'AND' ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "dependencies": {
-    "spdx-exceptions": "^1.0.0",
+    "spdx-exceptions": "^1.0.4",
     "spdx-license-ids": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Sorts ids and exceptions longest-first to ensure substrings don't confuse the parser, and adds a comprehensive test case to the README to ensure the bug stays fixed.
