### PR TITLE
Add `relaxed` option to allow invalid licenses and exception names 

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@
 var scan = require('./scan')
 var parse = require('./parse')
 
-module.exports = function (source) {
-  return parse(scan(source))
+module.exports = function (source, options) {
+  return parse(scan(source), options)
 }

--- a/scan.js
+++ b/scan.js
@@ -1,8 +1,5 @@
 'use strict'
 
-var licenses = require('spdx-license-ids')
-var exceptions = require('spdx-exceptions')
-
 module.exports = function (source) {
   var index = 0
 
@@ -80,22 +77,11 @@ module.exports = function (source) {
   }
 
   function identifier () {
-    var begin = index
     var string = idstring()
-
-    if (licenses.indexOf(string) !== -1) {
-      return {
-        type: 'LICENSE',
-        string: string
-      }
-    } else if (exceptions.indexOf(string) !== -1) {
-      return {
-        type: 'EXCEPTION',
-        string: string
-      }
+    return string && {
+      type: 'IDENTIFIER',
+      string: string
     }
-
-    index = begin
   }
 
   // Tries to read the next token. Returns `undefined` if no token is

--- a/test/index.js
+++ b/test/index.js
@@ -83,3 +83,27 @@ it('parses `AND`, `OR` and `WITH` with the correct precedence', function () {
     }
   )
 })
+
+it('rejects invalid license and exception names by default', function () {
+  assert.throws(
+    function () { p('unknownLicense') },
+    /`unknownLicense` is not a valid license name/
+  )
+
+  assert.throws(
+    function () { p('MIT WITH unknownException') },
+    /`unknownException` is not a valid exception name/
+  )
+})
+
+it('accepts invalid license and exception names in relaxed mode', function () {
+  assert.deepEqual(
+    p('unknownLicense', {relaxed: true}),
+    {license: 'unknownLicense'}
+  )
+
+  assert.deepEqual(
+    p('MIT WITH unknownException', {relaxed: true}),
+    {license: 'MIT', exception: 'unknownException'}
+  )
+})


### PR DESCRIPTION
Fix #11.