### PR TITLE
add licenseVisitor and noassertion type

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var scan = require('./scan')
 var parse = require('./parse')
 
-module.exports = function (source) {
-  return parse(scan(source))
+module.exports = function (source, options) {
+  options = options || {}
+  return parse(scan(source, options))
 }

--- a/parse.js
+++ b/parse.js
@@ -78,6 +78,9 @@ module.exports = function (tokens) {
         node.exception = exception
       }
       return node
+    } else if (t && t.type === 'NOASSERTION') {
+      next()
+      return {noassertion: true}
     }
   }
 

--- a/scan.js
+++ b/scan.js
@@ -83,10 +83,9 @@ module.exports = function (source, options) {
   }
 
   function identifier () {
-    var begin = index
     var string = idstring()
 
-    if (typeof options.licenseVisitor === 'function' ) {
+    if (typeof options.licenseVisitor === 'function') {
       string = options.licenseVisitor(string)
     }
 
@@ -106,8 +105,6 @@ module.exports = function (source, options) {
         string: string
       }
     }
-
-    index = begin
   }
 
   // Tries to read the next token. Returns `undefined` if no token is
@@ -130,7 +127,7 @@ module.exports = function (source, options) {
     }
 
     var token = parseToken()
-    if (!token || typeof token.string === 'undefined' ) {
+    if (!token || typeof token.string === 'undefined') {
       throw new Error('Unexpected `' + source[index] +
                       '` at offset ' + index)
     }

--- a/scan.js
+++ b/scan.js
@@ -5,7 +5,8 @@ var licenses = []
   .concat(require('spdx-license-ids/deprecated'))
 var exceptions = require('spdx-exceptions')
 
-module.exports = function (source) {
+module.exports = function (source, options) {
+  options = options || {}
   var index = 0
 
   function hasMore () {
@@ -85,6 +86,10 @@ module.exports = function (source) {
     var begin = index
     var string = idstring()
 
+    if (typeof options.licenseVisitor === 'function' ) {
+      string = options.licenseVisitor(string)
+    }
+
     if (licenses.indexOf(string) !== -1) {
       return {
         type: 'LICENSE',
@@ -93,6 +98,11 @@ module.exports = function (source) {
     } else if (exceptions.indexOf(string) !== -1) {
       return {
         type: 'EXCEPTION',
+        string: string
+      }
+    } else {
+      return {
+        type: 'NOASSERTION',
         string: string
       }
     }
@@ -120,7 +130,7 @@ module.exports = function (source) {
     }
 
     var token = parseToken()
-    if (!token) {
+    if (!token || typeof token.string === 'undefined' ) {
       throw new Error('Unexpected `' + source[index] +
                       '` at offset ' + index)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -83,3 +83,28 @@ it('parses `AND`, `OR` and `WITH` with the correct precedence', function () {
     }
   )
 })
+
+it('uses licenseVisitor to normalize licenseIdentifiers', function () {
+  assert.deepEqual(
+    p('mit OR Apache-2.0', { licenseVisitor: function (identifier) {
+      if (identifier === 'mit') return 'MIT'
+      return identifier
+    }}),
+    {
+      left: {license: 'MIT'},
+      conjunction: 'or',
+      right: {license: 'Apache-2.0'}
+    }
+  )
+})
+
+it('parses non-spdx licenses with noassertion', function () {
+  assert.deepEqual(
+    p('MIT OR Commercial'),
+    {
+      left: {license: 'MIT'},
+      conjunction: 'or',
+      right: {noassertion: true}
+    }
+  )
+})


### PR DESCRIPTION
adds licenseVisitor option to scan
   - could plug in something like spdx-correct
   - I would like to be able to at least correct casing of the identifiers within an expression

adds noassertion as a parsed type
  - today the parser throws when it hits an unrecognized expression
  - the thinking here is that the resulting expression could still have info
  -  an `MIT` license would still satisfy an expression like `MIT OR CustomLicense`
  - an `MIT` license would not satisfy an expression like `MIT AND CustomLicense`