### PR TITLE
Add option to skip validation of license names

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@
 var scan = require('./scan')
 var parse = require('./parse')
 
-module.exports = function (source) {
-  return parse(scan(source))
+module.exports = function (source, validateLicenseNames = true) {
+  return parse(scan(source, validateLicenseNames))
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@
 var scan = require('./scan')
 var parse = require('./parse')
 
-module.exports = function (source, validateLicenseNames = true) {
-  return parse(scan(source, validateLicenseNames))
+module.exports = function (source, doNotValidateLicenseNames = false, expectWhiteSpaceInLicenseNames = false) {
+  return parse(scan(source, doNotValidateLicenseNames, expectWhiteSpaceInLicenseNames))
 }

--- a/scan.js
+++ b/scan.js
@@ -127,7 +127,7 @@ module.exports = function (source, doNotValidateLicenseNames = false, expectWhit
     tokens.push(token)
   }
 
-  if(expectWhiteSpaceInLicenseNames){
+  if (expectWhiteSpaceInLicenseNames) {
     reduceExpandedLicenses(tokens)
   }
 
@@ -150,7 +150,7 @@ module.exports = function (source, doNotValidateLicenseNames = false, expectWhit
  * [ { type : LICENSE, string: 'Apache 2.0'}]
  *
  */
-function reduceExpandedLicenses(tokens) {
+function reduceExpandedLicenses (tokens) {
   var i = 0
   while (i < tokens.length) {
     if (i < tokens.length - 1 && tokens[i].type === 'LICENSE' && tokens[i + 1].type === 'LICENSE') {

--- a/scan.js
+++ b/scan.js
@@ -5,7 +5,7 @@ var licenses = []
   .concat(require('spdx-license-ids/deprecated'))
 var exceptions = require('spdx-exceptions')
 
-module.exports = function (source) {
+module.exports = function (source, validateLicenseNames = true) {
   var index = 0
 
   function hasMore () {
@@ -85,14 +85,14 @@ module.exports = function (source) {
     var begin = index
     var string = idstring()
 
-    if (licenses.indexOf(string) !== -1) {
-      return {
-        type: 'LICENSE',
-        string: string
-      }
-    } else if (exceptions.indexOf(string) !== -1) {
+    if (exceptions.indexOf(string) !== -1) {
       return {
         type: 'EXCEPTION',
+        string: string
+      }
+    } else if (licenses.indexOf(string) !== -1 || !validateLicenseNames) {
+      return {
+        type: 'LICENSE',
         string: string
       }
     }

--- a/scan.js
+++ b/scan.js
@@ -5,7 +5,7 @@ var licenses = []
   .concat(require('spdx-license-ids/deprecated'))
 var exceptions = require('spdx-exceptions')
 
-module.exports = function (source, validateLicenseNames = true) {
+module.exports = function (source, doNotValidateLicenseNames = false, expectWhiteSpaceInLicenseNames = false) {
   var index = 0
 
   function hasMore () {
@@ -90,7 +90,7 @@ module.exports = function (source, validateLicenseNames = true) {
         type: 'EXCEPTION',
         string: string
       }
-    } else if (licenses.indexOf(string) !== -1 || !validateLicenseNames) {
+    } else if (licenses.indexOf(string) !== -1 || doNotValidateLicenseNames) {
       return {
         type: 'LICENSE',
         string: string
@@ -118,7 +118,6 @@ module.exports = function (source, validateLicenseNames = true) {
     if (!hasMore()) {
       break
     }
-
     var token = parseToken()
     if (!token) {
       throw new Error('Unexpected `' + source[index] +
@@ -127,5 +126,39 @@ module.exports = function (source, validateLicenseNames = true) {
 
     tokens.push(token)
   }
+
+  if(expectWhiteSpaceInLicenseNames){
+    reduceExpandedLicenses(tokens)
+  }
+
   return tokens
+}
+
+/**
+ *
+ * @param {Array} tokens array of tokens that the scan generated
+ *
+ * This method deals with the case of license names spelled with whitespace.
+ * When doNotValidateLicenseNames is flagged true, license names as Apache 2.0 will generate this token array:
+ *
+ * [ {type: LICENSE, string: 'Apache'}, {type: LICENSE, string: '2.0'} ]
+ *
+ * which will then lead to errors thrown in the parser.
+ *
+ * After application of this method the token array will look like this:
+ *
+ * [ { type : LICENSE, string: 'Apache 2.0'}]
+ *
+ */
+function reduceExpandedLicenses(tokens) {
+  var i = 0
+  while (i < tokens.length) {
+    if (i < tokens.length - 1 && tokens[i].type === 'LICENSE' && tokens[i + 1].type === 'LICENSE') {
+      var concatName = tokens[i].string + ' ' + tokens[i + 1].string
+      tokens.splice(i + 1, 1)
+      tokens[i] = { type: 'LICENSE', string: concatName }
+    } else {
+      i += 1
+    }
+  }
 }


### PR DESCRIPTION
This option allows the parsing of license names that are not listed in the spdx-license-ids module.